### PR TITLE
Smarter video add/remove based on the video stream status.

### DIFF
--- a/components/videoChat/videoChat.js
+++ b/components/videoChat/videoChat.js
@@ -1,3 +1,4 @@
+import { Portal } from 'react-portal'
 import React from 'react'
 import SettingsButton from './controls/settingsButton'
 import Video from './video'
@@ -62,6 +63,8 @@ export default class VideoChat extends React.Component {
 
   render () {
     const { participants, localParticipant, status } = this.props.conference
+    const activeParticipants = participants.filter(p => p.isVideoTagActive)
+    const disabledParticipants = participants.filter(p => !p.isVideoTagActive)
 
     return status === 'joined' ? (
       <div className='videoChat'>
@@ -73,12 +76,19 @@ export default class VideoChat extends React.Component {
             </div>
           </div>
         </header>
-        <section className={this.getCssClasses(participants)}>
-          {participants.map(participant => (
-            <Video key={participant.id} audioTrack={participant.audioTrack} videoTrack={participant.videoTrack} isAudioMuted={participant.isAudioMuted} isVideoMuted={participant.isVideoMuted} isDominantSpeaker={participant.isDominantSpeaker} />
+        <section className={this.getCssClasses(activeParticipants)}>
+          {activeParticipants.map(participant => (
+            <Video key={participant.id} participant={participant} audioTrack={participant.audioTrack} videoTrack={participant.videoTrack} isAudioMuted={participant.isAudioMuted} isVideoMuted={participant.isVideoMuted} isDominantSpeaker={participant.isDominantSpeaker} />
           ))}
           <Video key={localParticipant.id} isLocal audioTrack={localParticipant.audioTrack} videoTrack={localParticipant.videoTrack} isAudioMuted={localParticipant.isAudioMuted} isVideoMuted={localParticipant.isVideoMuted} isDominantSpeaker={localParticipant.isDominantSpeaker} />
         </section>
+        <Portal>
+          <div className='disabledVideos'>
+            {disabledParticipants.map(participant => (
+              <Video key={participant.id} participant={participant} audioTrack={participant.audioTrack} videoTrack={participant.videoTrack} isAudioMuted={participant.isAudioMuted} isVideoMuted={participant.isVideoMuted} isDominantSpeaker={participant.isDominantSpeaker} />
+            ))}
+          </div>
+        </Portal>
         <VideoChatControls conference={this.conference} localParticipant={localParticipant} onLeave={this.props.onLeave} onToggleChat={this.props.onToggleChat} />
       </div>
     ) : null

--- a/lib/jitsiManager/jitsiParticipant.js
+++ b/lib/jitsiManager/jitsiParticipant.js
@@ -26,6 +26,7 @@ export default class JitsiParticipant extends EventEmitter {
   @observable status = undefined
   @observable isAudioMuted = false
   @observable isVideoMuted = false
+  @observable isVideoTagActive = false
 
   constructor (id, conference, displayName = undefined, isLocal = false) {
     super()

--- a/styles/app.scss
+++ b/styles/app.scss
@@ -750,3 +750,8 @@ $transparent-white: rgba(255,255,255, 0.97);
     font-size: 14px;
   }
 }
+
+// .videos get stashed here until they start or if they end unexpectedly
+.disabledVideos {
+  display: none;
+}


### PR DESCRIPTION
- Use events from the video tag to detect if video is active
- Use track rtc events to watch for a disconnect and disable video

This approach might not be necessary if the underlying connection to Jitsi was more responsive to disconnects. Once we switch to websockets, we should revisit how much of this is necessary. This also introduces some odd state updates to the participant from within the video component. It's not ideal but keeps overall state management simple.