### PR TITLE
Various screen sharing fixes

### DIFF
--- a/components/videoChat/controls/videoChatControls.tsx
+++ b/components/videoChat/controls/videoChatControls.tsx
@@ -22,7 +22,7 @@ export default class VideoChatControls extends React.Component<VideoChatControls
     super(props)
 
     // TODO: Safari should work but it's failing right now so disable it
-    this.canScreenCapture = DetectRTC.isScreenCapturingSupported && !DetectRTC.isMobileDevice && !DetectRTC.browser.isSafari
+    this.canScreenCapture = JitsiMeetJS.isDesktopSharingEnabled() && !DetectRTC.isMobileDevice
   }
 
   render (): JSX.Element {

--- a/jitsiMeetJS.d.ts
+++ b/jitsiMeetJS.d.ts
@@ -33,7 +33,7 @@ declare namespace JitsiMeetJS {
     facingMode?: string;
   }
 
-  function createLocalTracks(options: CreateLocalTracksOptions, firePermissionPromptIsShownEvent?: boolean)
+  function createLocalTracks(options: CreateLocalTracksOptions, firePermissionPromptIsShownEvent?: boolean);
 
   // TODO: Had to guess on return types
   interface VadProcessor {
@@ -42,7 +42,9 @@ declare namespace JitsiMeetJS {
     calculateAudioFrameVAD(pcmSample): number;
   }
 
-  function createTrackVADEmitter(localAudioDeviceId: string, sampleRate: number, vadProcessor: VadProcessor)
+  function createTrackVADEmitter(localAudioDeviceId: string, sampleRate: number, vadProcessor: VadProcessor);
+
+  function isDesktopSharingEnabled(): boolean;
 
   // Is there a better way to represent these?
   declare namespace logLevels {
@@ -358,6 +360,11 @@ declare namespace JitsiMeetJS {
 
     // This is undocumented. Private?
     getTrack(): MediaStreamTrack
+
+    // Undocumented
+    addEventListener(event: string, listener): void;
+
+    removeEventListener(event: string, listener): void;
   }
 
   // This seems to be for private use


### PR DESCRIPTION
1. Enabled sharing in Firefox and Safari.
2. Fixed stop sharing when using Chrome’s UI buttons.